### PR TITLE
fix: 修复midway-ts-boilerplate模板中package.json里启动server的名称不一致问题

### DIFF
--- a/midway-ts-boilerplate/boilerplate/_package.json
+++ b/midway-ts-boilerplate/boilerplate/_package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "start": "egg-scripts start --daemon --title=midway-server-{{name}} --framework=midway --ts",
-    "stop": "egg-scripts stop --title=egg-server-{{name}}",
+    "stop": "egg-scripts stop --title=midway-server-{{name}}",
     "start_build": "npm run build && cross-env NODE_ENV=development midway-bin dev",
     "clean": "midway-bin clean",
     "dev": "cross-env NODE_ENV=local midway-bin dev --ts",


### PR DESCRIPTION
## 问题描述

利用`midway-ts-boilerplate`模板创建的工程，由于`npm scripts`里，`start`和`stop`指定的`server name`不一致，导致启动服务后，无法停止！

## 解决方法

服务名称统一为`egg-server-{{name}}`还是`midway-server-{{name}}`，本PR是采用的后者。  

> `midway-ts-strict-boilerplate`这个模板里，又是统一的`egg-server`前缀！