### PR TITLE
chore: update '<>' to 'as'

### DIFF
--- a/midway-ts-boilerplate/boilerplate/src/config/config.default.ts
+++ b/midway-ts-boilerplate/boilerplate/src/config/config.default.ts
@@ -3,7 +3,7 @@ import { EggAppConfig, EggAppInfo, PowerPartial } from 'midway';
 export type DefaultConfig = PowerPartial<EggAppConfig>
 
 export default (appInfo: EggAppInfo) => {
-  const config = <DefaultConfig> {};
+  const config = {} as DefaultConfig;
 
   // use for cookie sign key, should change to your own and keep security
   config.keys = appInfo.name + '_{{keys}}';


### PR DESCRIPTION
执行 `tslint -c tslint.json --project .` 会报这个 error

Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.