### PR TITLE
fix: add cross-env in start command of v4 boilerplate

### DIFF
--- a/v4/midway-framework-koa/boilerplate/_package.json
+++ b/v4/midway-framework-koa/boilerplate/_package.json
@@ -28,7 +28,7 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "start": "NODE_ENV=production node ./bootstrap.js",
+    "start": "cross-env NODE_ENV=production node ./bootstrap.js",
     "dev": "cross-env NODE_ENV=local mwtsc --watch --run @midwayjs/mock/app.js",
     "test": "cross-env NODE_ENV=unittest jest",
     "cov": "jest --coverage",


### PR DESCRIPTION
In windows, it is not possible to specify environment variables directly before commanding without using cross-env.
windows下运行无法直接识别运行这个命令`"start": "NODE_ENV=production node ./bootstrap.js"`，因此需要添加一个cross-env